### PR TITLE
feat: implémentation d'une api cards

### DIFF
--- a/src/controllers/cards.controller.ts
+++ b/src/controllers/cards.controller.ts
@@ -1,0 +1,19 @@
+import { Request, Response } from "express";
+import { prisma } from "../database";
+
+export const getCards = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const cards = await prisma.card.findMany({
+      orderBy: {
+        pokedexNumber: "asc",
+      },
+    });
+
+    res.status(200).json(cards);
+  } catch (error) {
+    console.error("Error fetching cards:", error);
+    res.status(500).json({
+      error: "Internal server error",
+    });
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {env} from "./env";
 import express from "express";
 import cors from "cors";
 import authRoutes from "./routes/auth.routes";
+import cardsRoutes from "./routes/cards.routes";
 
 
 
@@ -19,6 +20,8 @@ app.use(
 
 app.use(express.json());
 app.use("/api/auth", authRoutes);
+app.use("/api/cards", cardsRoutes);
+
 
 
 // Serve static files (Socket.io test client)

--- a/src/routes/cards.routes.ts
+++ b/src/routes/cards.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { getCards } from "../controllers/cards.controller";
+
+const router = Router();
+
+router.get("/", getCards);
+
+export default router;


### PR DESCRIPTION
close #4 

Implémentation de l’endpoint GET /api/cards permettant de récupérer le catalogue complet des cartes Pokémon trié par pokedexNumber. Gestion des erreurs avec try/catch et retour des codes 200/500. Testé avec la collection Bruno fournie.





<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0429fa8d-e8d4-47e5-a6a2-62d53286dd89" />
